### PR TITLE
Adjust director to satisfy proxy.StreamDirector interface

### DIFF
--- a/server.go
+++ b/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 
 	"golang.org/x/net/context"
 )
@@ -38,7 +39,8 @@ func (s server) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	}
 
 	director := func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
-		return ctx, backendConn, nil
+		md, _ := metadata.FromIncomingContext(ctx)
+		return metadata.NewOutgoingContext(ctx, md.Copy()), backendConn, nil
 	}
 	grpcServer := grpc.NewServer(
 		grpc.CustomCodec(proxy.Codec()), // needed for proxy to function.

--- a/server.go
+++ b/server.go
@@ -37,8 +37,8 @@ func (s server) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		return s.next.ServeHTTP(w, r)
 	}
 
-	director := func(ctx context.Context, fullMethodName string) (*grpc.ClientConn, error) {
-		return backendConn, nil
+	director := func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+		return ctx, backendConn, nil
 	}
 	grpcServer := grpc.NewServer(
 		grpc.CustomCodec(proxy.Codec()), // needed for proxy to function.


### PR DESCRIPTION
Currently caddy-grpc plugin fails to compile due to following error:
```
../../pieterlouw/caddy-grpc/server.go:45:54: cannot use director (type func("context".Context, string) (*grpc.ClientConn, error)) as type proxy.StreamDirector in argument to proxy.TransparentHandler
```

This is solved by returning original context from director.