### PR TITLE
close connection to avoid leak

### DIFF
--- a/server.go
+++ b/server.go
@@ -19,7 +19,6 @@ type server struct {
 	next              httpserver.Handler
 	backendIsInsecure bool
 	backendTLS        *tls.Config
-	wrappedGrpc       *grpcweb.WrappedGrpcServer
 }
 
 // ServeHTTP satisfies the httpserver.Handler interface.
@@ -59,6 +58,7 @@ func (s server) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	wrappedGrpc := grpcweb.WrapServer(grpcServer, grpcweb.WithCorsForRegisteredEndpointsOnly(false))
 	wrappedGrpc.ServeHTTP(w, r)
 
+	backendConn.Close()
 	return 0, nil
 }
 


### PR DESCRIPTION
backend connection is created for each request, but not auto closed. The connection is kept open until timeout at backend server side. As request is handled synchronically, fix it by always closing backend connection.